### PR TITLE
Fix support for alarm action lists

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,5 +18,5 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm" {
   period = "${var.period}"
   threshold = "${var.threshold}"
   statistic = "${var.statistic}"
-  alarm_actions = "${var.alarm_action_arns}"
+  alarm_actions = ["${var.alarm_action_arns}"]
 }


### PR DESCRIPTION
When supplying a var to terraform, it behaves differently.