### PR TITLE
Add alarm description

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ resource "aws_cloudwatch_log_metric_filter" "metric_filter" {
 
 resource "aws_cloudwatch_metric_alarm" "metric_alarm" {
   alarm_name          = var.alarm_name
+  alarm_description   = var.alarm_description
   comparison_operator = var.comparison_operator
   evaluation_periods  = var.evaluation_periods
   metric_name         = aws_cloudwatch_log_metric_filter.metric_filter.name

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "alarm_name" {
   description = "The descriptive name for the alarm. This name must be unique within the user's AWS account"
 }
 
+variable "alarm_description" {
+  type        = string
+  description = "The description for the alarm"
+  default     = ""
+}
+
 variable "metric_filter_name" {
   type        = string
   description = "A name for the metric filter"


### PR DESCRIPTION
The module was missing the alarm description which prevented information about where the alarm raised from being described in it.

Enabling it with a default allows developer to add it so when it raises we can see the environment/any additional information.