### PR TITLE
Add a variable for `treat_missing_data`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm" {
   threshold           = var.threshold
   statistic           = var.statistic
   alarm_actions       = var.alarm_action_arns
+  treat_missing_data  = var.treat_missing_data
   tags                = { 
       notification_type = var.notification_type,
       severity = var.severity,

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,9 @@ variable "severity" {
   description = "(optional) The severity of this alarm. Either of the following is supported: Low, Medium, High, Critical"
   default     = "Medium"
 }
+
+variable "treat_missing_data" {
+  type        = string
+  description = "(optional) How the alarm is to handle missing data points. Either of the following is supported: missing, ignore, breaching, and notBreaching."
+  default     = "missing"
+}


### PR DESCRIPTION
Thanks for making this module open source, it was just what I was looking for.

Upstreaming a variable I added for my own use. I referred to the [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm#treat_missing_data) for how to word the description, but let me know if I should tweak the wording or anything. Thanks!